### PR TITLE
remove Rails dep by reading config path from ENV

### DIFF
--- a/lib/yard-api/templates/helpers/html_helper.rb
+++ b/lib/yard-api/templates/helpers/html_helper.rb
@@ -43,7 +43,7 @@ module YARD::Templates::Helpers::HtmlHelper
     readme_page = options.readme
     pages = Dir.glob(paths)
 
-    if readme_page.present? && !options.one_file
+    if readme_page && !options.one_file
       pages.delete_if { |page| page.match(readme_page) }
     end
 

--- a/lib/yard-api/yardoc_task.rb
+++ b/lib/yard-api/yardoc_task.rb
@@ -62,7 +62,7 @@ module YARD::APIPlugin
     private
 
     def load_config
-      path = Rails.root.join('config', 'yard_api.yml')
+      path = ENV.fetch('YARD_API_CONFIG') { Rails.root.join('config', 'yard_api.yml') }
 
       # load defaults
       config = YAML.load_file(File.join(YARD::APIPlugin::CONFIG_PATH, 'yard_api.yml'))


### PR DESCRIPTION
Yo @amireh - this is a cool project! :grinning:

I'm not sure if generating pretty static docs for a rubygem falls within the intended use case here - if not I'd love a pointer in the right direction to get slate-style docs into my gem. :+1: 

---

Adds the ability to specify a path in the YARD_API_CONFIG environment
variable. This means yard-api no longer has to depend on Rails.root to
load itself up, meaning it can be used in a plain ole' Ruby gem.

Also removes use of `.present?` since that's an ActiveSupport-ism.

With these two tweaks, yard-api successfully generates docs from static
pages in my gem.
