### PR TITLE
Adds :exclude option for static pages

### DIFF
--- a/examples/MyApp/Gemfile.lock
+++ b/examples/MyApp/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    yard-api (0.3.1)
+    yard-api (0.3.5)
       yard (= 0.8.7)
       yard-appendix
 
@@ -36,8 +36,7 @@ GEM
       tzinfo (~> 1.1)
     arel (5.0.1.20140414130214)
     builder (3.2.2)
-    columnize (0.8.9)
-    debugger-linecache (1.2.0)
+    byebug (8.2.3)
     erubis (2.7.0)
     i18n (0.7.0)
     json (1.8.3)
@@ -64,7 +63,6 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
-    slop (3.6.0)
     sprockets (3.2.0)
       rack (~> 1.0)
     sprockets-rails (2.3.2)
@@ -83,5 +81,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug
   rails (= 4.1.6)
   yard-api!
+
+BUNDLED WITH
+   1.11.2

--- a/examples/MyApp/config/yard_api.yml
+++ b/examples/MyApp/config/yard_api.yml
@@ -3,7 +3,7 @@ readme: doc/index.md
 static:
   - title: Secret Page
     path: doc/secret.md
-    exclude: true
+    exclude_from_sidebar: true
   - doc/*.md
 files:
   - app/controllers/**/*.rb

--- a/examples/MyApp/config/yard_api.yml
+++ b/examples/MyApp/config/yard_api.yml
@@ -1,5 +1,9 @@
 centered: true
+readme: doc/index.md
 static:
+  - title: Secret Page
+    path: doc/secret.md
+    exclude: true
   - doc/*.md
 files:
   - app/controllers/**/*.rb

--- a/lib/yard-api/templates/helpers/html_helper.rb
+++ b/lib/yard-api/templates/helpers/html_helper.rb
@@ -11,14 +11,14 @@ module YARD::Templates::Helpers::HtmlHelper
     link
   end
 
-  def static_pages()
-    @@static_pages ||= begin
-      all_static_pages.reject { |page| page[:exclude_from_sidebar] }
+  def visible_static_pages()
+    @@visible_static_pages ||= begin
+      static_pages.reject { |page| page[:exclude_from_sidebar] }
     end
   end
 
-  def all_static_pages()
-    @@all_static_pages ||= begin
+  def static_pages()
+    @@static_pages ||= begin
       locate_static_pages(YARD::APIPlugin.options)
     end
   end

--- a/lib/yard-api/templates/helpers/html_helper.rb
+++ b/lib/yard-api/templates/helpers/html_helper.rb
@@ -13,7 +13,7 @@ module YARD::Templates::Helpers::HtmlHelper
 
   def static_pages()
     @@static_pages ||= begin
-      all_static_pages.reject { |page| page[:exclude] }
+      all_static_pages.reject { |page| page[:exclude_from_sidebar] }
     end
   end
 
@@ -36,7 +36,7 @@ module YARD::Templates::Helpers::HtmlHelper
         end
 
         title_overrides[entry['path']] = entry['title']
-        excludes[entry['path']] = true if entry['exclude']
+        excludes[entry['path']] = true if entry['exclude_from_sidebar']
 
         entry['path']
       elsif entry.is_a?(Array)
@@ -71,7 +71,7 @@ module YARD::Templates::Helpers::HtmlHelper
         src: page,
         filename: filename,
         title: title,
-        exclude: !!excludes[page]
+        exclude_from_sidebar: !!excludes[page]
       }
     end.sort_by { |page| page[:title] }
   end

--- a/lib/yard-api/templates/helpers/html_helper.rb
+++ b/lib/yard-api/templates/helpers/html_helper.rb
@@ -13,12 +13,19 @@ module YARD::Templates::Helpers::HtmlHelper
 
   def static_pages()
     @@static_pages ||= begin
+      all_static_pages.reject { |page| page[:exclude] }
+    end
+  end
+
+  def all_static_pages()
+    @@all_static_pages ||= begin
       locate_static_pages(YARD::APIPlugin.options)
     end
   end
 
   def locate_static_pages(options)
     title_overrides = {}
+    excludes = {}
 
     paths = Array(options.static).map do |entry|
       pages = if entry.is_a?(Hash)
@@ -29,6 +36,7 @@ module YARD::Templates::Helpers::HtmlHelper
         end
 
         title_overrides[entry['path']] = entry['title']
+        excludes[entry['path']] = true if entry['exclude']
 
         entry['path']
       elsif entry.is_a?(Array)
@@ -62,7 +70,8 @@ module YARD::Templates::Helpers::HtmlHelper
       {
         src: page,
         filename: filename,
-        title: title
+        title: title,
+        exclude: !!excludes[page]
       }
     end.sort_by { |page| page[:title] }
   end

--- a/spec/helpers/html_helper_spec.rb
+++ b/spec/helpers/html_helper_spec.rb
@@ -19,18 +19,18 @@ describe YARD::Templates::Helpers::HtmlHelper do
     excluded.close(true)
   end
 
-  describe '#static_pages' do
+  describe '#visible_static_pages' do
     it 'excludes pages with exclude_from_sidebar option' do
-      pages = html.static_pages
+      pages = html.visible_static_pages
       expect(pages.count).to eq(1)
       expect(pages[0][:title]).to eq('Included')
       expect(pages[0][:exclude_from_sidebar]).to be_falsey
     end
   end
 
-  describe '#all_static_pages' do
+  describe '#static_pages' do
     it 'includes pages with exclude_from_sidebar option' do
-      pages = html.all_static_pages
+      pages = html.static_pages
       expect(pages.count).to eq(2)
 
       page = pages.find { |p| p[:exclude_from_sidebar] }

--- a/spec/helpers/html_helper_spec.rb
+++ b/spec/helpers/html_helper_spec.rb
@@ -10,7 +10,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
     Registry.clear
     set_option('static', [
       {'path' => included.path, 'title' => 'Included'},
-      {'path' => excluded.path, 'title' => 'Excluded', 'exclude' => true}
+      {'path' => excluded.path, 'title' => 'Excluded', 'exclude_from_sidebar' => true}
     ])
   end
 
@@ -20,20 +20,20 @@ describe YARD::Templates::Helpers::HtmlHelper do
   end
 
   describe '#static_pages' do
-    it 'excludes pages with exclude option' do
+    it 'excludes pages with exclude_from_sidebar option' do
       pages = html.static_pages
       expect(pages.count).to eq(1)
       expect(pages[0][:title]).to eq('Included')
-      expect(pages[0][:exclude]).to be_falsey
+      expect(pages[0][:exclude_from_sidebar]).to be_falsey
     end
   end
 
   describe '#all_static_pages' do
-    it 'includes pages with exclude option' do
+    it 'includes pages with exclude_from_sidebar option' do
       pages = html.all_static_pages
       expect(pages.count).to eq(2)
 
-      page = pages.find { |p| p[:exclude] }
+      page = pages.find { |p| p[:exclude_from_sidebar] }
       expect(page).to_not be_nil
       expect(page[:title]).to eq('Excluded')
     end

--- a/spec/helpers/html_helper_spec.rb
+++ b/spec/helpers/html_helper_spec.rb
@@ -2,12 +2,13 @@ require 'spec_helper'
 require 'tempfile'
 
 describe YARD::Templates::Helpers::HtmlHelper do
-  let(:html) { Class.new { extend YARD::Templates::Helpers::HtmlHelper } }
+  let(:html) { Class.new { include YARD::Templates::Helpers::HtmlHelper }.new }
   let(:included) { Tempfile.new('included') }
   let(:excluded) { Tempfile.new('excluded') }
 
   before do
-    Registry.clear
+    html.singleton_class.class_variable_set(:@@static_pages, nil)
+    html.singleton_class.class_variable_set(:@@visible_static_pages, nil)
     set_option('static', [
       {'path' => included.path, 'title' => 'Included'},
       {'path' => excluded.path, 'title' => 'Excluded', 'exclude_from_sidebar' => true}

--- a/spec/helpers/html_helper_spec.rb
+++ b/spec/helpers/html_helper_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'tempfile'
+
+describe YARD::Templates::Helpers::HtmlHelper do
+  let(:html) { Class.new { extend YARD::Templates::Helpers::HtmlHelper } }
+  let(:included) { Tempfile.new('included') }
+  let(:excluded) { Tempfile.new('excluded') }
+
+  before do
+    Registry.clear
+    set_option('static', [
+      {'path' => included.path, 'title' => 'Included'},
+      {'path' => excluded.path, 'title' => 'Excluded', 'exclude' => true}
+    ])
+  end
+
+  after do
+    included.close(true)
+    excluded.close(true)
+  end
+
+  describe '#static_pages' do
+    it 'excludes pages with exclude option' do
+      pages = html.static_pages
+      expect(pages.count).to eq(1)
+      expect(pages[0][:title]).to eq('Included')
+      expect(pages[0][:exclude]).to be_falsey
+    end
+  end
+
+  describe '#all_static_pages' do
+    it 'includes pages with exclude option' do
+      pages = html.all_static_pages
+      expect(pages.count).to eq(2)
+
+      page = pages.find { |p| p[:exclude] }
+      expect(page).to_not be_nil
+      expect(page[:title]).to eq('Excluded')
+    end
+  end
+end

--- a/templates/api/fulldoc/html/setup.rb
+++ b/templates/api/fulldoc/html/setup.rb
@@ -99,7 +99,7 @@ def generate_assets
 end
 
 def serialize_static_pages
-  static_pages.each do |page|
+  all_static_pages.each do |page|
     options[:file] = page[:src]
     serialize(page[:filename])
     options.delete(:file)

--- a/templates/api/fulldoc/html/setup.rb
+++ b/templates/api/fulldoc/html/setup.rb
@@ -99,7 +99,7 @@ def generate_assets
 end
 
 def serialize_static_pages
-  all_static_pages.each do |page|
+  static_pages.each do |page|
     options[:file] = page[:src]
     serialize(page[:filename])
     options.delete(:file)

--- a/templates/api/layout/html/layout.erb
+++ b/templates/api/layout/html/layout.erb
@@ -16,7 +16,7 @@
     <% if options[:all_resources] %>
       <div id="content">
         <% if api_options.one_file %>
-          <% static_pages.each do |page| %>
+          <% visible_static_pages.each do |page| %>
             <%= diskfile page[:src] %>
           <% end %>
         <% end %>

--- a/templates/api/layout/html/sidebar.erb
+++ b/templates/api/layout/html/sidebar.erb
@@ -15,7 +15,7 @@
       )
     %>
 
-    <% static_pages.each do |page| %>
+    <% visible_static_pages.each do |page| %>
       <%=
         sidebar_link(page[:filename], page[:title], object == page[:filename])
       %>

--- a/templates/api/onefile/html/sidebar.erb
+++ b/templates/api/onefile/html/sidebar.erb
@@ -4,7 +4,7 @@
   </h1>
 
   <nav id="static_pages">
-    <% static_pages.each do |page| %>
+    <% visible_static_pages.each do |page| %>
       <%= sidebar_link(page[:title], page[:filename]) %>
     <% end %>
 


### PR DESCRIPTION
Fixes #4 

Adds exclude option for static pages, example `config/yard_api.yml`:

    static:
      - title: Secret Page
        path: doc/secret.md
        exclude: true
      - doc/*.md

Added spec uses `Tempfile` to satisfy `Dir.glob`, but let me know if you prefer fixtures or mocking. Also let me know if you prefer a different option name like `hide` or `hidden`.
