### PR TITLE
Allow `yard-api` to work with latest `redcarpet` and `yard`

### DIFF
--- a/lib/yard-api/markup/redcarpet.rb
+++ b/lib/yard-api/markup/redcarpet.rb
@@ -17,7 +17,7 @@ module YARD::APIPlugin::Markup
     }.freeze
 
     RendererOptions = {
-    }.freeze
+    }
 
     def initialize(text, extensions_and_options=nil)
       @renderer = Redcarpet::Render::HTML.new(RendererOptions)

--- a/lib/yard-api/templates/helpers/html_helper.rb
+++ b/lib/yard-api/templates/helpers/html_helper.rb
@@ -100,7 +100,7 @@ module YARD::Templates::Helpers::HtmlHelper
     end
   end
 
-  def sidebar_link(href, title, is_active)
+  def sidebar_link(href, title, is_active=false)
     link_url(href, title, { class: is_active ? 'active' : '' })
   end
 


### PR DESCRIPTION
I removed `.freeze` from `RendererOptions` of `redcarpet.rb` because at least the latest version (3.4.0) of `redcarpet` requires that hash to be modifiable to initialize, or throw the following exception
```
can't modify frozen Hash
/home/ec2-user/yard-api/lib/yard-api/markup/redcarpet.rb:24:in `merge!'
/home/ec2-user/yard-api/lib/yard-api/markup/redcarpet.rb:24:in `new'
/home/ec2-user/yard-api/lib/yard-api/markup/redcarpet.rb:24:in `initialize'
/home/ec2-user/.rvm/gems/ruby-2.4.4/gems/yard-0.9.16/lib/yard/templates/helpers/html_helper.rb:85:in `new'
/home/ec2-user/.rvm/gems/ruby-2.4.4/gems/yard-0.9.16/lib/yard/templates/helpers/html_helper.rb:85:in `html_markup_markdown'
/home/ec2-user/yard-api/lib/yard-api/templates/helpers/html_helper.rb:120:in `htmlify'
...
```

I also set the default of `is_active` to `false` in `sidebar_link` because it is sometimes invoked with 2 parameters instead of 3 throwing the following exception
```
ArgumentError: wrong number of arguments (given 2, expected 3)
/home/ec2-user/.rvm/gems/ruby-2.4.4/gems/yard-api-1.0.1/lib/yard-api/templates/helpers/html_helper.rb:103:in `sidebar_link'
/home/ec2-user/.rvm/gems/ruby-2.4.4/gems/yard-api-1.0.1/templates/api/onefile/html/sidebar.erb:5:in `_erb_cache_3'
/home/ec2-user/.rvm/gems/ruby-2.4.4/gems/yard-0.9.16/lib/yard/templates/template.rb:288:in `erb'
/home/ec2-user/.rvm/gems/ruby-2.4.4/gems/yard-api-1.0.1/templates/api/layout/html/layout.erb:15:in `_erb_cache_0'
/home/ec2-user/.rvm/gems/ruby-2.4.4/gems/yard-0.9.16/lib/yard/templates/template.rb:288:in `erb'
/home/ec2-user/.rvm/gems/ruby-2.4.4/gems/yard-0.9.16/lib/yard/templates/template.rb:370:in `render_section'
...
```