### PR TITLE
Add Boolean config include_internal

### DIFF
--- a/doc/tags/internal.md
+++ b/doc/tags/internal.md
@@ -2,6 +2,8 @@
 
 Mark an object to be _internal_ so that it does not show up in the API docs. This is equivalent to not defining an `@API` tag on the object.
 
+You can set the Boolean config `include_internal` to `true` if you want objects marked as _internal_ to show up in the API docs anyway. By that mechanism it is possible to generate "internal use only" documentation sets which include documentation for things that shouldn't be in the publicly-accessible documentation.
+
 
 ## Example
 

--- a/lib/yard-api/verifier.rb
+++ b/lib/yard-api/verifier.rb
@@ -22,13 +22,14 @@ module YARD
       end
 
       def relevant_object?(object)
+        doc_include_internal = !!YARD::APIPlugin.options[:include_internal]
         case object.type
         when :root, :module, :constant
           false
         when :api
           true
         when :method
-          return false if object.has_tag?(:internal) || !object.has_tag?(:API)
+          return false if object.has_tag?(:internal) && !doc_include_internal || !object.has_tag?(:API)
           routes = @routes[object.object_id]
           routes ||= begin
             @routes[object.object_id] = YARD::Templates::Helpers::RouteHelper.routes_for_yard_object(object)
@@ -43,7 +44,7 @@ module YARD
 
           routes.any?
         when :class
-          return false if object.has_tag?(:internal) || !object.has_tag?(:API)
+          return false if object.has_tag?(:internal) && !doc_include_internal || !object.has_tag?(:API)
           true
         else
           object.parent.nil? && relevant_object?(object.parent)


### PR DESCRIPTION
If { include_internal: true } is set in the yard-api
config, it will ignore @internal tags and create
documentation for those classes/methods anyway.

This will be useful for generating documentation sets
for internal use, as opposed to those intended for
public consumption which should omit any classes or
methods marked as "internal use only" with @internal.