### PR TITLE
Fix exception when generating JSON docs

### DIFF
--- a/templates/api/fulldoc/json/setup.rb
+++ b/templates/api/fulldoc/json/setup.rb
@@ -129,15 +129,9 @@ def get_route(object)
   route = routes.first
 
   if route.present?
-    verb = if route.verb.source =~ /\^?(\w*)\$/
-      $1.upcase
-    else
-      route.verb.source
-    end
-
     {
-      path: route.path.spec.to_s.gsub("(.:format)", ""),
-      verb: verb
+      path: RouteHelper.get_route_path(route),
+      verb: RouteHelper.get_route_verb(route)
     }
   end
 end


### PR DESCRIPTION
If RouteHelper.api_methods_for_controller_and_action returns a route
with a verb that is a String instead of a Regexp, the get_route
method of the fulldoc/json method will throw an exception when
it tries to access route.verb.source.

This changes the route parsing of that method to use the RouteHelper
methods get_route_verb and get_route_path, which handle the types
better.