### PR TITLE
Fix broken CSS links on individual resources pages

### DIFF
--- a/templates/api/fulldoc/html/setup.rb
+++ b/templates/api/fulldoc/html/setup.rb
@@ -7,7 +7,7 @@ include YARD::Templates::Helpers::FilterHelper
 def init
   logger.info "YARD-API: starting."
 
-  options.serializer ||= YARD::APIPlugin::Serializer.new
+  options.serializer = YARD::APIPlugin::Serializer.new
   options.serializer.basepath = api_options.output
 
   options[:resources] = options.objects.


### PR DESCRIPTION
In commit 4329ed1, a change was made that broke the generation
of the individual resources pages. The CSS links no longer point
to the correct location for the CSS files and the other embedded
links do not point to the correct locations.

This change backs out the change that is causing this problem.